### PR TITLE
Add PGC RMSD simulation script

### DIFF
--- a/examples/pgc_rmsd_simulation.py
+++ b/examples/pgc_rmsd_simulation.py
@@ -2,23 +2,19 @@
 Saves per-trial RMSDs, summaries, and example curves + plots.
 
 Run:
-  python3 examples/pgc_rmsd_simulation.py --n 5000 --angles 360 --repeats 1000 --seed 42 --outdir results
+  python3 examples/pgc_rmsd_simulation.py \
+    --n 5000 --angles 360 --repeats 1000 \
+    --seed 42 --outdir results
 """
 
 from __future__ import annotations
 import argparse
 from pathlib import Path
-import sys
 import time
 import numpy as np
 import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
-
-script_dir = Path(__file__).resolve().parent
-src_dir = script_dir / "src"
-if src_dir.exists() and str(src_dir) not in sys.path:
-    sys.path.insert(0, str(src_dir))
 
 from polargini.pgc import polar_gini_curve
 from polargini.metrics import rmsd
@@ -58,7 +54,10 @@ def main():
     args = ap.parse_args()
 
     print(
-        f"Config: n={args.n}, angles={args.angles}, repeats={args.repeats}, seed={args.seed}, outdir={args.outdir}"
+        (
+            f"Config: n={args.n}, angles={args.angles}, repeats={args.repeats}, "
+            f"seed={args.seed}, outdir={args.outdir}"
+        )
     )
 
     data_dir = args.outdir
@@ -72,8 +71,11 @@ def main():
     t1 = time.perf_counter()
     r = np.sqrt(points[:, 0] ** 2 + points[:, 1] ** 2)
     print(
-        f"Sampled {args.n} points uniformly from unit disk in {t1 - t0:.3f}s. "
-        f"points.shape={points.shape}, r[min,mean,max]=[{r.min():.3f},{r.mean():.3f},{r.max():.3f}]"
+        (
+            f"Sampled {args.n} points uniformly from unit disk in {t1 - t0:.3f}s. "
+            f"points.shape={points.shape}, "
+            f"r[min,mean,max]=[{r.min():.3f},{r.mean():.3f},{r.max():.3f}]"
+        )
     )
 
     labels = np.zeros(args.n, dtype=int)
@@ -81,9 +83,12 @@ def main():
     t2 = time.perf_counter()
     angles, _ = polar_gini_curve(points, labels, num_angles=args.angles)
     t3 = time.perf_counter()
+    first5 = [round(x, 2) for x in np.degrees(angles[:5])]
     print(
-        f"Computed base angles for PGC in {t3 - t2:.3f}s: count={len(angles)}, "
-        f"first5(deg)={[round(x,2) for x in np.degrees(angles[:5])] }"
+        (
+            f"Computed base angles for PGC in {t3 - t2:.3f}s: count={len(angles)}, "
+            f"first5(deg)={first5}"
+        )
     )
 
     rows: list[tuple[int, int, float]] = []
@@ -91,10 +96,10 @@ def main():
     example_bg = None
     example_fg = None
 
-    block = max(1, args.repeats // 10)
+    block = max(2, args.repeats // 10)
     for m in PERCENTAGES:
-        print(f"Processing percentage: {m}% (k={int(round(args.n * m / 100))})")
         k = int(round(args.n * m / 100))
+        print(f"Processing percentage: {m}% (k={k})")
         tm0 = time.perf_counter()
         for i in range(args.repeats):
             fg_idx = rng.choice(args.n, size=k, replace=False)
@@ -107,8 +112,11 @@ def main():
 
             if (i % block) == 0:
                 print(
-                    f"  m={m}% trial={i}/{args.repeats} RMSD={val:.6f} bg[min,max]=[{bg_curve.min():.4f},{bg_curve.max():.4f}] "
-                    f"fg[min,max]=[{fg_curve.min():.4f},{fg_curve.max():.4f}]"
+                    (
+                        f"  m={m}% trial={i}/{args.repeats} RMSD={val:.6f} "
+                        f"bg[min,max]=[{bg_curve.min():.4f},{bg_curve.max():.4f}] "
+                        f"fg[min,max]=[{fg_curve.min():.4f},{fg_curve.max():.4f}]"
+                    )
                 )
 
             if m == 50 and i == 0:
@@ -121,7 +129,10 @@ def main():
         last_block = rows[-args.repeats :]
         vals = np.fromiter((v[2] for v in last_block), dtype=float, count=args.repeats)
         print(
-            f"Completed m={m}% in {tm1 - tm0:.3f}s: RMSD[min,mean,max]=[{vals.min():.6f},{vals.mean():.6f},{vals.max():.6f}]"
+            (
+                f"Completed m={m}% in {tm1 - tm0:.3f}s: "
+                f"RMSD[min,mean,max]=[{vals.min():.6f},{vals.mean():.6f},{vals.max():.6f}]"
+            )
         )
 
     df = pd.DataFrame(rows, columns=["m", "trial", "rmsd"])
@@ -145,8 +156,10 @@ def main():
     csv_summary = data_dir / "pgc_sim1_rmsd_summary.csv"
     summary.to_csv(csv_summary, index=False)
     print(
-        f"Saved summary statistics to CSV: {csv_summary} in {t5 - t4:.3f}s.\n"
-        f"Summary head:\n{summary.head().to_string(index=False)}"
+        (
+            f"Saved summary statistics to CSV: {csv_summary} in {t5 - t4:.3f}s.\n"
+            f"Summary head:\n{summary.head().to_string(index=False)}"
+        )
     )
 
     if example_angles is not None:
@@ -171,6 +184,7 @@ def main():
     ax.set_title("RMSD between foreground and background PGCs")
     ax.legend()
     fig.tight_layout()
+    plots_dir.mkdir(parents=True, exist_ok=True)
     save_fig(fig, plots_dir, "pgc_sim1_rmsd_summary")
     plt.close(fig)
 

--- a/examples/pgc_rmsd_simulation.py
+++ b/examples/pgc_rmsd_simulation.py
@@ -1,106 +1,210 @@
-#!/usr/bin/env python3
-"""Simulate PGC RMSD for random foreground selections."""
+"""Simulate PGC RMSD for random foreground selections (Simulation 1).
+Saves per-trial RMSDs, summaries, and example curves + plots.
+
+Run:
+  python3 examples/pgc_rmsd_simulation.py --n 5000 --angles 360 --repeats 1000 --seed 42 --outdir results
+"""
 
 from __future__ import annotations
-
-import sys
+import argparse
 from pathlib import Path
-
+import sys
+import time
 import numpy as np
+import pandas as pd
+import seaborn as sns
 import matplotlib.pyplot as plt
 
-script_dir = Path(__file__).resolve().parent.parent
+script_dir = Path(__file__).resolve().parent
 src_dir = script_dir / "src"
 if src_dir.exists() and str(src_dir) not in sys.path:
     sys.path.insert(0, str(src_dir))
 
-from polargini.pgc import polar_gini_curve  # noqa: E402
-from polargini.metrics import rmsd  # noqa: E402
-from polargini.plotting import plot_pgc  # noqa: E402
+from polargini.pgc import polar_gini_curve
+from polargini.metrics import rmsd
+from polargini.plotting import plot_pgc
 
-
-N_POINTS = 5000
 PERCENTAGES = np.arange(5, 100, 5)
-REPEATS = 1000
-NUM_ANGLES = 360
 
 
-def sample_unit_disk(n: int, rng: np.random.Generator) -> np.ndarray:
-    """Sample ``n`` points uniformly from the unit disk."""
-    r = np.sqrt(rng.random(n))
-    theta = rng.random(n) * 2 * np.pi
-    x = r * np.cos(theta)
-    y = r * np.sin(theta)
-    return np.column_stack((x, y))
+def sample_unit_disk_rejection(n: int, rng: np.random.Generator) -> np.ndarray:
+    """Uniform unit disk via sampling-by-rejection."""
+    pts = []
+    while len(pts) < n:
+        xy = rng.uniform(-1.0, 1.0, size=(n, 2))
+        mask = (xy[:, 0] ** 2 + xy[:, 1] ** 2) <= 1.0
+        pts.extend(xy[mask].tolist())
+    arr = np.asarray(pts[:n], dtype=float)
+    return arr
 
 
-def main() -> None:
-    rng = np.random.default_rng(0)
+def save_fig(fig: plt.Figure, outdir: Path, name: str, *, dpi: int = 150) -> None:
+    """Save a figure as PNG and SVG under outdir with a standard name."""
+    outdir.mkdir(parents=True, exist_ok=True)
+    png = outdir / f"{name}.png"
+    svg = outdir / f"{name}.svg"
+    fig.savefig(png, dpi=dpi, bbox_inches="tight")
+    fig.savefig(svg, dpi=dpi, bbox_inches="tight")
+    print(f"Saved figure: {png} and {svg}")
 
-    points = sample_unit_disk(N_POINTS, rng)
 
-    rmsd_values: dict[int, np.ndarray] = {}
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n", type=int, default=5000, help="number of points")
+    ap.add_argument("--angles", type=int, default=360, help="number of angles")
+    ap.add_argument("--repeats", type=int, default=1000, help="trials per m")
+    ap.add_argument("--seed", type=int, default=42, help="random seed")
+    ap.add_argument("--outdir", type=Path, default=Path("results"), help="output dir")
+    args = ap.parse_args()
 
-    example_angles: np.ndarray | None = None
-    example_curves: tuple[np.ndarray, np.ndarray] | None = None
+    print(
+        f"Config: n={args.n}, angles={args.angles}, repeats={args.repeats}, seed={args.seed}, outdir={args.outdir}"
+    )
 
+    data_dir = args.outdir
+    plots_dir = args.outdir / "plots"
+    args.outdir.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng(args.seed)
+
+    t0 = time.perf_counter()
+    points = sample_unit_disk_rejection(args.n, rng)
+    t1 = time.perf_counter()
+    r = np.sqrt(points[:, 0] ** 2 + points[:, 1] ** 2)
+    print(
+        f"Sampled {args.n} points uniformly from unit disk in {t1 - t0:.3f}s. "
+        f"points.shape={points.shape}, r[min,mean,max]=[{r.min():.3f},{r.mean():.3f},{r.max():.3f}]"
+    )
+
+    labels = np.zeros(args.n, dtype=int)
+    labels[: args.n // 2] = 1
+    t2 = time.perf_counter()
+    angles, _ = polar_gini_curve(points, labels, num_angles=args.angles)
+    t3 = time.perf_counter()
+    print(
+        f"Computed base angles for PGC in {t3 - t2:.3f}s: count={len(angles)}, "
+        f"first5(deg)={[round(x,2) for x in np.degrees(angles[:5])] }"
+    )
+
+    rows: list[tuple[int, int, float]] = []
+    example_angles = None
+    example_bg = None
+    example_fg = None
+
+    block = max(1, args.repeats // 10)
     for m in PERCENTAGES:
-        k = int(N_POINTS * m / 100)
-        vals = np.empty(REPEATS, dtype=float)
-
-        for i in range(REPEATS):
-            fg_idx = rng.choice(N_POINTS, size=k, replace=False)
-            labels = np.zeros(N_POINTS, dtype=int)
+        print(f"Processing percentage: {m}% (k={int(round(args.n * m / 100))})")
+        k = int(round(args.n * m / 100))
+        tm0 = time.perf_counter()
+        for i in range(args.repeats):
+            fg_idx = rng.choice(args.n, size=k, replace=False)
+            labels = np.zeros(args.n, dtype=int)
             labels[fg_idx] = 1
-
-            angles, curves = polar_gini_curve(points, labels, num_angles=NUM_ANGLES)
+            _, curves = polar_gini_curve(points, labels, num_angles=args.angles)
             bg_curve, fg_curve = curves[0], curves[1]
-            vals[i] = rmsd(bg_curve, fg_curve)
+            val = rmsd(bg_curve, fg_curve)
+            rows.append((int(m), int(i), float(val)))
+
+            if (i % block) == 0:
+                print(
+                    f"  m={m}% trial={i}/{args.repeats} RMSD={val:.6f} bg[min,max]=[{bg_curve.min():.4f},{bg_curve.max():.4f}] "
+                    f"fg[min,max]=[{fg_curve.min():.4f},{fg_curve.max():.4f}]"
+                )
 
             if m == 50 and i == 0:
                 example_angles = angles
-                example_curves = (bg_curve, fg_curve)
+                example_bg = bg_curve
+                example_fg = fg_curve
+                print("  Stored example curves for m=50%, i=0")
 
-        rmsd_values[m] = vals
+        tm1 = time.perf_counter()
+        last_block = rows[-args.repeats :]
+        vals = np.fromiter((v[2] for v in last_block), dtype=float, count=args.repeats)
+        print(
+            f"Completed m={m}% in {tm1 - tm0:.3f}s: RMSD[min,mean,max]=[{vals.min():.6f},{vals.mean():.6f},{vals.max():.6f}]"
+        )
 
-    means = []
-    stds = []
-    lowers = []
-    uppers = []
-    for m in PERCENTAGES:
-        v = rmsd_values[m]
-        means.append(float(np.mean(v)))
-        stds.append(float(np.std(v, ddof=1)))
-        q = np.quantile(v, [0.025, 0.975])
-        lowers.append(float(q[0]))
-        uppers.append(float(q[1]))
+    df = pd.DataFrame(rows, columns=["m", "trial", "rmsd"])
+    csv_trials = data_dir / "pgc_sim1_rmsd_by_m.csv"
+    df.to_csv(csv_trials, index=False)
+    print(f"Saved per-trial RMSD data to CSV: {csv_trials} (rows={len(df)})")
+
+    t4 = time.perf_counter()
+    summary = (
+        df.groupby("m")["rmsd"]
+        .agg(
+            mean_rmsd="mean",
+            sd_rmsd=lambda x: x.std(ddof=1),
+            q025=lambda x: x.quantile(0.025),
+            q975=lambda x: x.quantile(0.975),
+            n_trials_effective="count",
+        )
+        .reset_index()
+    )
+    t5 = time.perf_counter()
+    csv_summary = data_dir / "pgc_sim1_rmsd_summary.csv"
+    summary.to_csv(csv_summary, index=False)
+    print(
+        f"Saved summary statistics to CSV: {csv_summary} in {t5 - t4:.3f}s.\n"
+        f"Summary head:\n{summary.head().to_string(index=False)}"
+    )
+
+    if example_angles is not None:
+        ex = pd.DataFrame(
+            {
+                "theta_deg": np.degrees(example_angles),
+                "pgc_back": example_bg,
+                "pgc_fore": example_fg,
+            }
+        )
+        csv_ex = data_dir / "pgc_sim1_example_curves_m50.csv"
+        ex.to_csv(csv_ex, index=False)
+        print(f"Saved example PGC curves for m=50% to CSV: {csv_ex}")
 
     fig, ax = plt.subplots(figsize=(8, 5))
-    ax.plot(PERCENTAGES, means, label="Mean RMSD")
-    ax.fill_between(PERCENTAGES, lowers, uppers, alpha=0.2, label="2.5–97.5%")
+    ax.plot(summary["m"], summary["mean_rmsd"], label="Mean RMSD")
+    ax.fill_between(
+        summary["m"], summary["q025"], summary["q975"], alpha=0.2, label="2.5–97.5%"
+    )
     ax.set_xlabel("Expressing percentage (%)")
     ax.set_ylabel("RMSD")
     ax.set_title("RMSD between foreground and background PGCs")
     ax.legend()
     fig.tight_layout()
+    save_fig(fig, plots_dir, "pgc_sim1_rmsd_summary")
+    plt.close(fig)
 
-    if example_angles is not None and example_curves is not None:
+    if example_angles is not None:
         fig2, ax2 = plt.subplots(subplot_kw={"projection": "polar"})
         plot_pgc(
             example_angles,
-            example_curves[0],
-            example_curves[1],
+            example_bg,
+            example_fg,
             ax=ax2,
             labels=["Background", "Foreground"],
         )
         ax2.set_title("Example PGC (m=50%)", pad=20)
         fig2.tight_layout()
+        save_fig(fig2, plots_dir, "pgc_sim1_example_curves_m50")
+        plt.close(fig2)
 
-    plt.show()
+    try:
+        fig3, ax3 = plt.subplots(figsize=(9, 5))
+        sns.violinplot(data=df, x="m", y="rmsd", ax=ax3, inner="quartile", cut=0)
+        ax3.set_xlabel("Expressing percentage (%)")
+        ax3.set_ylabel("RMSD")
+        ax3.set_title("RMSD distribution by expressing %")
+        fig3.tight_layout()
+        save_fig(fig3, plots_dir, "pgc_sim1_rmsd_violin")
+        plt.close(fig3)
+    except Exception as e:
+        print(f"Failed to create violin plot: {e}")
 
-    print("m%\tmean\tstd\t2.5%\t97.5%")
-    for m, mean, std, lo, hi in zip(PERCENTAGES, means, stds, lowers, uppers):
-        print(f"{m:2d}\t{mean:.6f}\t{std:.6f}\t{lo:.6f}\t{hi:.6f}")
+    print("m%\tmean\tstd\t2.5%\t97.5%\tn")
+    for _, row in summary.iterrows():
+        print(
+            f"{int(row['m']):2d}\t{row['mean_rmsd']:.6f}\t{row['sd_rmsd']:.6f}\t{row['q025']:.6f}\t{row['q975']:.6f}\t{int(row['n_trials_effective'])}"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/pgc_rmsd_simulation.py
+++ b/examples/pgc_rmsd_simulation.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Simulate PGC RMSD for random foreground selections."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+script_dir = Path(__file__).resolve().parent.parent
+src_dir = script_dir / "src"
+if src_dir.exists() and str(src_dir) not in sys.path:
+    sys.path.insert(0, str(src_dir))
+
+from polargini.pgc import polar_gini_curve  # noqa: E402
+from polargini.metrics import rmsd  # noqa: E402
+from polargini.plotting import plot_pgc  # noqa: E402
+
+
+N_POINTS = 5000
+PERCENTAGES = np.arange(5, 100, 5)
+REPEATS = 1000
+NUM_ANGLES = 360
+
+
+def sample_unit_disk(n: int, rng: np.random.Generator) -> np.ndarray:
+    """Sample ``n`` points uniformly from the unit disk."""
+    r = np.sqrt(rng.random(n))
+    theta = rng.random(n) * 2 * np.pi
+    x = r * np.cos(theta)
+    y = r * np.sin(theta)
+    return np.column_stack((x, y))
+
+
+def main() -> None:
+    rng = np.random.default_rng(0)
+
+    points = sample_unit_disk(N_POINTS, rng)
+
+    rmsd_values: dict[int, np.ndarray] = {}
+
+    example_angles: np.ndarray | None = None
+    example_curves: tuple[np.ndarray, np.ndarray] | None = None
+
+    for m in PERCENTAGES:
+        k = int(N_POINTS * m / 100)
+        vals = np.empty(REPEATS, dtype=float)
+
+        for i in range(REPEATS):
+            fg_idx = rng.choice(N_POINTS, size=k, replace=False)
+            labels = np.zeros(N_POINTS, dtype=int)
+            labels[fg_idx] = 1
+
+            angles, curves = polar_gini_curve(points, labels, num_angles=NUM_ANGLES)
+            bg_curve, fg_curve = curves[0], curves[1]
+            vals[i] = rmsd(bg_curve, fg_curve)
+
+            if m == 50 and i == 0:
+                example_angles = angles
+                example_curves = (bg_curve, fg_curve)
+
+        rmsd_values[m] = vals
+
+    means = []
+    stds = []
+    lowers = []
+    uppers = []
+    for m in PERCENTAGES:
+        v = rmsd_values[m]
+        means.append(float(np.mean(v)))
+        stds.append(float(np.std(v, ddof=1)))
+        q = np.quantile(v, [0.025, 0.975])
+        lowers.append(float(q[0]))
+        uppers.append(float(q[1]))
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.plot(PERCENTAGES, means, label="Mean RMSD")
+    ax.fill_between(PERCENTAGES, lowers, uppers, alpha=0.2, label="2.5–97.5%")
+    ax.set_xlabel("Expressing percentage (%)")
+    ax.set_ylabel("RMSD")
+    ax.set_title("RMSD between foreground and background PGCs")
+    ax.legend()
+    fig.tight_layout()
+
+    if example_angles is not None and example_curves is not None:
+        fig2, ax2 = plt.subplots(subplot_kw={"projection": "polar"})
+        plot_pgc(
+            example_angles,
+            example_curves[0],
+            example_curves[1],
+            ax=ax2,
+            labels=["Background", "Foreground"],
+        )
+        ax2.set_title("Example PGC (m=50%)", pad=20)
+        fig2.tight_layout()
+
+    plt.show()
+
+    print("m%\tmean\tstd\t2.5%\t97.5%")
+    for m, mean, std, lo, hi in zip(PERCENTAGES, means, stds, lowers, uppers):
+        print(f"{m:2d}\t{mean:.6f}\t{std:.6f}\t{lo:.6f}\t{hi:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ requires-python = ">=3.9"
 dependencies = ["numpy>=1.20", "pandas>=1.1"]
 
 [project.optional-dependencies]
-plot = ["matplotlib>=3.3"]
+plot = ["matplotlib>=3.3", "seaborn>=0.11"]
 io = ["scipy>=1.5"]
 legacy = ["scipy>=1.5", "h5py>=3.0", "openpyxl>=3.0"]
 dev = [


### PR DESCRIPTION
## Summary
- add example script to simulate random foreground selections in a unit disk and compute RMSD between foreground and background Polar Gini Curves
- visualize mean RMSD with 95% quantile bands and show an example curve pair

## Testing
- `ruff check examples/pgc_rmsd_simulation.py`
- `ruff check .` *(fails: legacy/spatial_MOB_analysis.py:43:89: E501 Line too long (90 > 88))*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c83661e10832daa11d48801e1aab1